### PR TITLE
Create ProductGroupContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `ProductGroupContext`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,3 @@
 # product-group-context
+
+Provides the product group context to shelf child blocks.

--- a/react/ProductGroupContext.tsx
+++ b/react/ProductGroupContext.tsx
@@ -1,0 +1,43 @@
+import React, { useContext, useMemo, useState, useCallback } from 'react'
+
+interface Context {
+  items: Item[]
+  addItemToGroup: (product: Product, item: SKU) => () => void
+}
+
+const ProductGroupContext = React.createContext<Context | undefined>(undefined)
+
+export const ProductGroupProvider: React.FC = ({ children }) => {
+  const [itemMap, setItemMap] = useState<Record<string, Item>>({})
+
+  const addItemToGroup = useCallback((product: Product, selectedItem: SKU) => {
+    setItemMap(prevItemMap => ({
+      ...prevItemMap,
+      [selectedItem.itemId]: { product, selectedItem },
+    }))
+
+    return function removeItemFromGroup() {
+      setItemMap(({ [selectedItem.itemId]: item, ...prevMap }) => prevMap)
+    }
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({
+      items: Object.values(itemMap),
+      addItemToGroup,
+    }),
+    [itemMap, addItemToGroup]
+  )
+
+  return (
+    <ProductGroupContext.Provider value={contextValue}>
+      {children}
+    </ProductGroupContext.Provider>
+  )
+}
+
+export const useProductGroup = () => {
+  return useContext(ProductGroupContext)
+}
+
+export default { ProductGroupProvider, useProductGroup }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,74 @@
+interface CommertialOffer {
+  AvailableQuantity: number
+  Installments: Installment[]
+  ListPrice: number
+  Price: number
+  PriceWithoutDiscount: number
+  Tax: number
+  taxPercentage: number
+}
+
+interface Installment {
+  InterestRate: number
+  Name: string
+  NumberOfInstallments: number
+  TotalValuePlusInterestRate: number
+  Value: number
+}
+
+interface Seller {
+  addToCartLink: string
+  commertialOffer: CommertialOffer
+  sellerId: string
+  sellerDefault: boolean
+  sellerName: string
+}
+
+interface Image {
+  imageTag: string
+  imageText: string
+  imageUrl: string
+}
+
+interface SKU {
+  ean: string
+  image: Image
+  images: Image[]
+  itemId: string
+  measurementUnit: string
+  name: string
+  nameComplete: string
+  seller: Seller
+  sellers: Seller[]
+}
+
+interface PriceRange {
+  highPrice: number
+  lowPrice: number
+}
+
+interface ProductPriceRange {
+  listPrice: PriceRange
+  sellingPrice: PriceRange
+}
+
+interface Product {
+  brand: string
+  brandId: number
+  cacheId: string
+  categories: string[]
+  items: SKU[]
+  link: string
+  linkText: string
+  priceRange: ProductPriceRange
+  productId: string
+  productName: string
+  productReference: string
+  sku?: SKU
+  specificationGroups: any[]
+}
+
+interface Item {
+  product: Product
+  selectedItem: SKU
+}


### PR DESCRIPTION
Currently, the information about `product` and `selectedItem` is only in the `ProductSummaryContext`, because we always used this information in the `ProductSummary`. 
However, now we need to have this information in a Context external to the `ProductSummary`, this is because at Shelf `BuyTogether` we need to deal with several different products to add them all to the cart with a single click on a button that is outside the `ProductSummary`. That way, we need the `ProductGroupContext` to get the products and items selected in the Shelf easier.

Testing:

- [Workspace](https://thalyta3--storecomponents.myvtex.com/blouse-with-knot/p)
- Click the add to cart button of BuyTogether shelf